### PR TITLE
Add associated size value to text case

### DIFF
--- a/ConfettiView-NSHipster.podspec
+++ b/ConfettiView-NSHipster.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/nshipster'
 
   s.ios.deployment_target = '10.0'
-  s.swift_versions = ['4.0', '4.2', '5.0']
+  s.swift_versions = ['5.1']
 
   s.source_files = 'ConfettiView/Classes/**/*'
 

--- a/ConfettiView/Classes/ConfettiView.swift
+++ b/ConfettiView/Classes/ConfettiView.swift
@@ -102,7 +102,7 @@ public final class ConfettiView: UIView {
         case image(UIImage, UIColor?)
 
         /// A string of characters.
-        case text(String)
+        case text(String, Double = 16.0)
     }
 
     // MARK: -
@@ -206,9 +206,9 @@ fileprivate extension ConfettiView.Content {
             return shape.image(with: .white)
         case let .image(image, _):
             return image
-        case let .text(string):
+        case let .text(string, size):
             let defaultAttributes: [NSAttributedString.Key: Any] = [
-                .font: UIFont.systemFont(ofSize: 16.0)
+                .font: UIFont.systemFont(ofSize: CGFloat(size))
             ]
 
             return NSAttributedString(string: "\(string)", attributes: defaultAttributes).image()

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ confettiView.emit(with: [
 For more information,
 see [the accompanying blog post on NSHipster](https://nshipster.com/caemitterlayer/).
 
-<br clear="both"/> 
+<br clear="both"/>
 
 ## Example
 
@@ -37,6 +37,7 @@ clone the repo and run `pod install` from the Example directory.
 ## Requirements
 
 - iOS 10.0+
+- Swift 5.1+
 
 ## Installation
 


### PR DESCRIPTION
Default values for associated values require Swift >= 5.1, so this change drops support for Swift 5.0 and earlier.