### PR TITLE
Fixes issue with infinite emitting  

### DIFF
--- a/Sources/ConfettiView/ConfettiView.swift
+++ b/Sources/ConfettiView/ConfettiView.swift
@@ -53,7 +53,7 @@ public final class ConfettiView: UIView {
         animation.keyTimes = [0, 0.5, 1]
         animation.isRemovedOnCompletion = false
 
-        layer.beginTime = CACurrentMediaTime()
+        layer.beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         layer.birthRate = 1.0
 
         CATransaction.begin()


### PR DESCRIPTION
Hey,
This PR fixes issue with infinite emitting 🎉 by converting `CACurrentMediaTime` to `Layer`  time space. 

I faced same issue as in https://github.com/NSHipster/ConfettiView/issues/4.
